### PR TITLE
Add LibXMLTrampolines target and C trampolines for Swift integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,12 +25,19 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "ya-swift-html-xml-parser",
-            dependencies: ["CLibXML2"],
+            dependencies: ["CLibXML2", "LibXMLTrampolines"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 .enableExperimentalFeature("NonescapableTypes"),
                 .enableUpcomingFeature("InternalImportsByDefault")
             ]
+        ),
+        .target(
+            name: "LibXMLTrampolines",
+            dependencies: ["CLibXML2"],
+            path: "Sources/LibXMLTrampolines",
+            publicHeadersPath: "include"
+
         ),
         .systemLibrary(
             name: "CLibXML2",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add ya-swift-html-xml-parser as a dependency to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/3a4oT/ya-swift-html-xml-parser.git", from: "0.0.1")
+    .package(url: "https://github.com/3a4oT/ya-swift-html-xml-parser.git", from: "0.1.0")
 ]
 ```
 

--- a/Sources/LibXMLTrampolines/LibXMLTrampolines.c
+++ b/Sources/LibXMLTrampolines/LibXMLTrampolines.c
@@ -1,0 +1,57 @@
+#include "LibXMLTrampolines.h"
+#include <string.h>
+
+// ---- C trampolines that simply forward to Swift global functions ----
+
+static void _startDocument(void *ctx) {
+    swift_xml_startDocument(ctx);
+}
+
+static void _endDocument(void *ctx) {
+    swift_xml_endDocument(ctx);
+}
+
+static void _startElement(void *ctx, const xmlChar *name, const xmlChar **attrs) {
+    swift_xml_startElement(ctx, name, attrs);
+}
+
+static void _endElement(void *ctx, const xmlChar *name) {
+    swift_xml_endElement(ctx, name);
+}
+
+static void _characters(void *ctx, const xmlChar *ch, int len) {
+    swift_xml_characters(ctx, ch, len);
+}
+
+static void _comment(void *ctx, const xmlChar *value) {
+    swift_xml_comment(ctx, value);
+}
+
+static void _cdata(void *ctx, const xmlChar *value, int len) {
+    swift_xml_cdata(ctx, value, len);
+}
+
+static void _processingInstruction(void *ctx, const xmlChar *target, const xmlChar *data) {
+    swift_xml_processingInstruction(ctx, target, data);
+}
+
+static void _error(void *ctx, const char *msg, ...) {
+    // libxml2 sends printf-style varargs; we just forward the raw message string.
+    swift_xml_error(ctx, msg);
+}
+
+// Public function: fill handler with pointers to the above trampolines
+void libxml_install_swift_trampolines(xmlSAXHandler *handler) {
+    if (!handler) return;
+    memset(handler, 0, sizeof(xmlSAXHandler));
+
+    handler->startDocument        = _startDocument;
+    handler->endDocument          = _endDocument;
+    handler->startElement         = _startElement;
+    handler->endElement           = _endElement;
+    handler->characters           = _characters;
+    handler->comment              = _comment;
+    handler->cdataBlock           = _cdata;
+    handler->processingInstruction= _processingInstruction;
+    handler->error                = (errorSAXFunc) _error;
+}

--- a/Sources/LibXMLTrampolines/include/LibXMLTrampolines.h
+++ b/Sources/LibXMLTrampolines/include/LibXMLTrampolines.h
@@ -1,0 +1,29 @@
+#ifndef LIBXML_TRAMPOLINES_H
+#define LIBXML_TRAMPOLINES_H
+
+#include <libxml/parser.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Forward declarations of Swift bridge functions (implemented with @_cdecl in Swift)
+void swift_xml_startDocument(void *ctx);
+void swift_xml_endDocument(void *ctx);
+void swift_xml_startElement(void *ctx, const xmlChar *name, const xmlChar **attrs);
+void swift_xml_endElement(void *ctx, const xmlChar *name);
+void swift_xml_characters(void *ctx, const xmlChar *ch, int len);
+void swift_xml_comment(void *ctx, const xmlChar *value);
+void swift_xml_cdata(void *ctx, const xmlChar *value, int len);
+void swift_xml_processingInstruction(void *ctx, const xmlChar *target, const xmlChar *data);
+void swift_xml_error(void *ctx, const char *msg);
+
+// Fills the provided xmlSAXHandler structure with C trampolines that forward
+// into the Swift @_cdecl functions above.
+void libxml_install_swift_trampolines(xmlSAXHandler *handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBXML_TRAMPOLINES_H */

--- a/Sources/ya-swift-html-xml-parser/Stream/StreamParserTrampolines.swift
+++ b/Sources/ya-swift-html-xml-parser/Stream/StreamParserTrampolines.swift
@@ -1,0 +1,89 @@
+import CLibXML2
+import LibXMLTrampolines
+
+@inline(__always)
+private func cString(_ ptr: UnsafePointer<xmlChar>) -> String {
+    String(cString: UnsafePointer<CChar>(OpaquePointer(ptr)))
+}
+
+// MARK: - Bridging C trampolines to Swift events
+
+@_cdecl("swift_xml_startDocument")
+func swift_xml_startDocument(_ ctx: UnsafeMutableRawPointer?) {
+    guard let ctx else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    parser.deliver(.startDocument)
+}
+
+@_cdecl("swift_xml_endDocument")
+func swift_xml_endDocument(_ ctx: UnsafeMutableRawPointer?) {
+    guard let ctx else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    parser.deliver(.endDocument)
+}
+
+@_cdecl("swift_xml_startElement")
+func swift_xml_startElement(_ ctx: UnsafeMutableRawPointer?, _ name: UnsafePointer<xmlChar>?, _ attrs: UnsafePointer<UnsafePointer<xmlChar>?>?) {
+    guard let ctx, let name else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    let elementName = cString(name)
+    var attributes: [(String, String)] = []
+    if let attrs {
+        var i = 0
+        while let attrNamePtr = attrs[i] {
+            let valuePtr = attrs[i + 1]
+            let attrName = cString(attrNamePtr)
+            let value = valuePtr.map { cString($0) } ?? ""
+            attributes.append((attrName, value))
+            i += 2
+        }
+    }
+    parser.deliver(.startElement(name: elementName, attributes: attributes))
+}
+
+@_cdecl("swift_xml_endElement")
+func swift_xml_endElement(_ ctx: UnsafeMutableRawPointer?, _ name: UnsafePointer<xmlChar>?) {
+    guard let ctx, let name else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    parser.deliver(.endElement(name: cString(name)))
+}
+
+@_cdecl("swift_xml_characters")
+func swift_xml_characters(_ ctx: UnsafeMutableRawPointer?, _ ch: UnsafePointer<xmlChar>?, _ len: Int32) {
+    guard let ctx, let ch else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    let str = String(decoding: UnsafeBufferPointer(start: ch, count: Int(len)), as: UTF8.self)
+    parser.deliver(.characters(str))
+}
+
+@_cdecl("swift_xml_comment")
+func swift_xml_comment(_ ctx: UnsafeMutableRawPointer?, _ value: UnsafePointer<xmlChar>?) {
+    guard let ctx, let value else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    parser.deliver(.comment(cString(value)))
+}
+
+@_cdecl("swift_xml_cdata")
+func swift_xml_cdata(_ ctx: UnsafeMutableRawPointer?, _ value: UnsafePointer<xmlChar>?, _ len: Int32) {
+    guard let ctx, let value else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    let cdata = String(decoding: UnsafeBufferPointer(start: value, count: Int(len)), as: UTF8.self)
+    parser.deliver(.cdata(cdata))
+}
+
+@_cdecl("swift_xml_processingInstruction")
+func swift_xml_processingInstruction(_ ctx: UnsafeMutableRawPointer?, _ target: UnsafePointer<xmlChar>?, _ data: UnsafePointer<xmlChar>?) {
+    guard let ctx, let target else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    let targetString = cString(target)
+    let dataString = data.map { cString($0) }
+    parser.deliver(.processingInstruction(target: targetString, data: dataString))
+}
+
+@_cdecl("swift_xml_error")
+func swift_xml_error(_ ctx: UnsafeMutableRawPointer?, _ msg: UnsafePointer<CChar>?) {
+    guard let ctx, let msg else { return }
+    let parser = Unmanaged<StreamParser>.fromOpaque(ctx).takeUnretainedValue()
+    let message = String(cString: msg)
+    parser.deliver(.error(message.trimmingWhitespace()))
+}


### PR DESCRIPTION
- Introduced a new target `LibXMLTrampolines` to facilitate communication between C and Swift.
- Implemented C functions in `LibXMLTrampolines.c` that forward SAX events from libxml2 to Swift.
- Updated `StreamParser` to utilize the new trampolines for handling XML events, improving performance and maintainability.
- Removed the previous inline SAX handler implementation in favor of the new trampoline approach.